### PR TITLE
KM-19 update: update API to return sprint name

### DIFF
--- a/app/controllers/sprints_controller.rb
+++ b/app/controllers/sprints_controller.rb
@@ -12,6 +12,7 @@ class SprintsController < ApplicationController
             sprint_attrs = sprint.attrs
             {
               id: sprint_attrs['id'],
+              name: sprint_attrs['name'],
               state: sprint_attrs['state'],
               start_date: sprint_attrs['startDate'],
               end_date: sprint_attrs['endDate']

--- a/spec/controllers/sprints_controller_spec.rb
+++ b/spec/controllers/sprints_controller_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe SprintsController, :type => :controller do
         expect(json_data.count).to eq test_data.count
 
         json_data.each_with_index do |data, i|
+          expect(data["name"]).to eq test_data[i]["name"]
           expect(data["state"]).to eq test_data[i]["state"]
           if data["state"] == "closed" || data["state"] == "active"
             expect(data["start_date"]).to eq test_data[i]["startDate"]


### PR DESCRIPTION
## Summary
1. Update API to return sprint name
API: `/sprints/board_sprints`
Response:
```
{
    "status": 200,
    "message": "Success SprintsController#board_sprints",
    "data": [
        {
            "id":,
            "name":,
            "state":,
            "start_date":,
            "end_date":
        },
        {
            "id":,
            "name":,
            "state":,
            "start_date":,
            "end_date":
        }
    ]
}
```
