### PR TITLE
KM-22 BE bug: worklogs cannot be taken if jira key is unexpected format

### DIFF
--- a/app/controllers/productivities_controller.rb
+++ b/app/controllers/productivities_controller.rb
@@ -82,11 +82,11 @@ class ProductivitiesController < ApplicationController
     work_logs.each do |work_log|
       log_at = work_log['started'].to_date
       time_spent_seconds = work_log['timeSpentSeconds'] || 0
-      if work_log['author']['key'] == @jira_id && log_at < @sprint_start_date
+      if work_log['author']['name'] == @jira_id && log_at < @sprint_start_date
         carried_over_logs_total += time_spent_seconds
-      elsif work_log['author']['key'] == @jira_id && log_at > @sprint_end_date
+      elsif work_log['author']['name'] == @jira_id && log_at > @sprint_end_date
         do_over_logs_total += time_spent_seconds
-      elsif work_log['author']['key'] == @jira_id
+      elsif work_log['author']['name'] == @jira_id
         sprint_work_logs_total += time_spent_seconds
       end
     end

--- a/app/controllers/sprints_controller.rb
+++ b/app/controllers/sprints_controller.rb
@@ -8,8 +8,10 @@ class SprintsController < ApplicationController
       @board_sprints =
         Rails.cache.fetch("sprint_productivity_board_id_#{board_id}") do
           board = @client.Board.find(board_id)
-          board.sprints.map do |sprint|
+          sprints = board.sprints.map do |sprint|
             sprint_attrs = sprint.attrs
+            next if sprint_attrs['state'] == 'future'
+
             {
               id: sprint_attrs['id'],
               name: sprint_attrs['name'],
@@ -18,6 +20,7 @@ class SprintsController < ApplicationController
               end_date: sprint_attrs['endDate']
             }
           end
+          sprints.compact
         end
       response_success(self.class.name, self.action_name, @board_sprints)
     end

--- a/spec/controllers/sprints_controller_spec.rb
+++ b/spec/controllers/sprints_controller_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe SprintsController, :type => :controller do
         expect(response.status).to eq 200
         json_data = JSON.parse(response.body)["data"]
         test_data = JSON.parse(File.read("#{Rails.root}/spec/fixtures/jira/rest/agile/1.0/board_key_sprint_response.json"))["values"]
-        expect(json_data.count).to eq test_data.count
+        # future sprint is not collected
+        expect(json_data.count).to eq test_data.count - 1
 
         json_data.each_with_index do |data, i|
           expect(data["name"]).to eq test_data[i]["name"]


### PR DESCRIPTION
## Summary
1. Change processing to get worklog with jira name from jira key
2. Get only closed and active sprints
```
