### PR TITLE
KM-28 add: create API to store current remaining time into DB

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,46 +1,76 @@
 class ReportsController < ApplicationController
   include JiraInitializer
 
-  def total_remaing_time_in_sprint
+  def save_sprint_remaining_time
+    sprint_id = params[:sprint_id]
+    return response_bad_request if sprint_id.blank?
+
+    users = User.all
+    sprint_remaining_times = { sprint_id: sprint_id, remaining_times: [] }
+    created_at = Time.zone.now
+    ActiveRecord::Base.transaction do
+      users.each do |user|
+        remaining_time = 0
+        jira_id = user.jira_id
+        if jira_id.blank?
+          logger.warn "This user doesn't have jira_id. user_id: #{user_id}"
+          next
+        end
+        logger.info "---User: #{jira_id} Sprint Remaining Time---"
+        issues = @client.Issue.jql(
+          "Sprint = #{sprint_id} AND assignee in (#{jira_id})",
+          fields: [:key, :status, :timetracking],
+          max_results: 5000,
+          start_index:0
+        )
+        issues.each do |issue|
+          issue_fields = issue.attrs['fields']
+          if issue_fields['status']['statusCategory']['key'] != 'done'
+            issue_remaining_time = issue_fields['timetracking']['remainingEstimateSeconds']
+            logger.info "Issue: #{issue.attrs['key']}, Remaining Time: #{issue_remaining_time}"
+            remaining_time += issue_remaining_time
+          end
+        end
+        user_id = user.id
+        SprintRemainingTime.create!(user_id: user_id, jira_id: jira_id, sprint_id: sprint_id, remaining_time: remaining_time, created_at: created_at)
+        sprint_remaining_times[:remaining_times] << { user_id: user_id, jira_id: jira_id, remaining_time: remaining_time }
+      end
+    end
+    response_success(self.class.name, self.action_name, sprint_remaining_times)
+  rescue => e
+    if e.class.name == "JIRA::HTTPError"
+      response_bad_request
+    else
+      response_internal_server_error
+    end
+  end
+
+  def total_sprint_remaining_time
     user_ids = params[:user_ids].split(',').map(&:to_i)
     sprint_id = params[:sprint_id]
-    @total_remaing_time_in_sprint =
-      Rails.cache.fetch("total_remaing_time_in_sprint_user_ids_#{user_ids.join('-')}_sprint_id_#{sprint_id}") do
+    @total_sprint_remaining_time =
+      Rails.cache.fetch("total_sprint_remaining_time_user_ids_#{user_ids.join('-')}_sprint_id_#{sprint_id}") do
         return response_bad_request if sprint_id.blank?
 
         users = User.where(id: user_ids)
         not_found_user_ids = user_ids - users.ids
         logger.warn "These user cannot be found. user_ids: #{not_found_user_ids}" if not_found_user_ids.present?
 
-        total_remaing_time_in_sprint = { sprint_id: sprint_id, total_remaing_times: [] }
-        users.each do |user|
-          total_remaing_time_hash = { user_id:  user.id, jira_id: '', total_remaing_time: 0 }
-          jira_id = user.jira_id
-          if jira_id.blank?
-            logger.warn "This user doesn't have jira_id. user_id: #{user_id}"
-            total_remaing_time_in_sprint[:total_remaing_times] << total_remaing_time_hash
-            next
+        total_sprint_remaining_time = { sprint_id: sprint_id, total_remaining_times: [] }
+        sprint_remaining_times = SprintRemainingTime.where(user_id: users.ids).group_by(&:created_at)
+        sprint_remaining_times.keys.each do |created_at|
+          hash = { date: created_at, remaining_times: [] }
+          sprint_remaining_times[created_at].each do |sprint_remaining_time|
+            hash[:remaining_times] << {
+              jira_id: sprint_remaining_time.jira_id,
+              remaining_time: sprint_remaining_time.remaining_time
+            }
           end
-          total_remaing_time_hash[:jira_id] = jira_id
-          begin
-            issues = @client.Issue.jql(
-              "Sprint = #{sprint_id} AND assignee in (#{jira_id})",
-              fields: [:key, :status, :timetracking],
-              max_results: 5000,
-              start_index:0
-            )
-            issues.each do |issue|
-              issue_fields = issue.attrs['fields']
-              if issue_fields['status']['statusCategory']['key'] != 'done'
-                total_remaing_time_hash[:total_remaing_time] += issue_fields['timetracking']['remainingEstimateSeconds']
-              end
-            end
-            total_remaing_time_in_sprint[:total_remaing_times] << total_remaing_time_hash
-          end
+          total_sprint_remaining_time[:total_remaining_times] << hash
         end
-        total_remaing_time_in_sprint
+        total_sprint_remaining_time
       end
-    response_success(self.class.name, self.action_name, @total_remaing_time_in_sprint)
+    response_success(self.class.name, self.action_name, @total_sprint_remaining_time)
   rescue => e
     if e.class.name == "JIRA::HTTPError"
       response_bad_request

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,15 +1,16 @@
 class ReportsController < ApplicationController
   include JiraInitializer
 
-  def save_sprint_remaining_time
+  def save_sprint_time_tracking
     sprint_id = params[:sprint_id]
     return response_bad_request if sprint_id.blank?
 
     users = User.all
-    sprint_remaining_times = { sprint_id: sprint_id, remaining_times: [] }
+    sprint_time_trackings = { sprint_id: sprint_id, time_trackings: [] }
     created_at = Time.zone.now
     ActiveRecord::Base.transaction do
       users.each do |user|
+        time_spent = 0
         remaining_time = 0
         jira_id = user.jira_id
         if jira_id.blank?
@@ -25,18 +26,21 @@ class ReportsController < ApplicationController
         )
         issues.each do |issue|
           issue_fields = issue.attrs['fields']
+          issue_time_spent = issue_fields['timetracking']['timeSpentSeconds'].to_i
+          logger.info "Issue: #{issue.attrs['key']}, Time Spent: #{issue_time_spent}"
+          time_spent += issue_time_spent
           if issue_fields['status']['statusCategory']['key'] != 'done'
-            issue_remaining_time = issue_fields['timetracking']['remainingEstimateSeconds']
+            issue_remaining_time = issue_fields['timetracking']['remainingEstimateSeconds'].to_i
             logger.info "Issue: #{issue.attrs['key']}, Remaining Time: #{issue_remaining_time}"
             remaining_time += issue_remaining_time
           end
         end
         user_id = user.id
-        SprintRemainingTime.create!(user_id: user_id, jira_id: jira_id, sprint_id: sprint_id, remaining_time: remaining_time, created_at: created_at)
-        sprint_remaining_times[:remaining_times] << { user_id: user_id, jira_id: jira_id, remaining_time: remaining_time }
+        SprintTimeTracking.create!(user_id: user_id, jira_id: jira_id, sprint_id: sprint_id, time_spent: time_spent, remaining_time: remaining_time, created_at: created_at)
+        sprint_time_trackings[:time_trackings] << { user_id: user_id, jira_id: jira_id, time_spent: time_spent, remaining_time: remaining_time }
       end
     end
-    response_success(self.class.name, self.action_name, sprint_remaining_times)
+    response_success(self.class.name, self.action_name, sprint_time_trackings)
   rescue => e
     if e.class.name == "JIRA::HTTPError"
       response_bad_request
@@ -45,32 +49,33 @@ class ReportsController < ApplicationController
     end
   end
 
-  def total_sprint_remaining_time
+  def total_sprint_time_tracking
     user_ids = params[:user_ids].split(',').map(&:to_i)
     sprint_id = params[:sprint_id]
-    @total_sprint_remaining_time =
-      Rails.cache.fetch("total_sprint_remaining_time_user_ids_#{user_ids.join('-')}_sprint_id_#{sprint_id}") do
+    @total_sprint_time_tracking =
+      Rails.cache.fetch("total_sprint_time_tracking_user_ids_#{user_ids.join('-')}_sprint_id_#{sprint_id}") do
         return response_bad_request if sprint_id.blank?
 
         users = User.where(id: user_ids)
         not_found_user_ids = user_ids - users.ids
         logger.warn "These user cannot be found. user_ids: #{not_found_user_ids}" if not_found_user_ids.present?
 
-        total_sprint_remaining_time = { sprint_id: sprint_id, total_remaining_times: [] }
-        sprint_remaining_times = SprintRemainingTime.where(user_id: users.ids).group_by(&:created_at)
-        sprint_remaining_times.keys.each do |created_at|
-          hash = { date: created_at, remaining_times: [] }
-          sprint_remaining_times[created_at].each do |sprint_remaining_time|
-            hash[:remaining_times] << {
-              jira_id: sprint_remaining_time.jira_id,
-              remaining_time: sprint_remaining_time.remaining_time
+        total_sprint_time_tracking = { sprint_id: sprint_id, total_time_trackings: [] }
+        sprint_time_trackings = SprintTimeTracking.where(sprint_id: sprint_id, user_id: users.ids).group_by(&:created_at)
+        sprint_time_trackings.keys.each do |created_at|
+          hash = { date: created_at, time_trackings: [] }
+          sprint_time_trackings[created_at].each do |sprint_time_tracking|
+            hash[:time_trackings] << {
+              jira_id: sprint_time_tracking.jira_id,
+              time_spent: sprint_time_tracking.time_spent,
+              remaining_time: sprint_time_tracking.remaining_time
             }
           end
-          total_sprint_remaining_time[:total_remaining_times] << hash
+          total_sprint_time_tracking[:total_time_trackings] << hash
         end
-        total_sprint_remaining_time
+        total_sprint_time_tracking
       end
-    response_success(self.class.name, self.action_name, @total_sprint_remaining_time)
+    response_success(self.class.name, self.action_name, @total_sprint_time_tracking)
   rescue => e
     if e.class.name == "JIRA::HTTPError"
       response_bad_request

--- a/app/models/sprint_remaining_time.rb
+++ b/app/models/sprint_remaining_time.rb
@@ -1,2 +1,0 @@
-class SprintRemainingTime < ApplicationRecord
-end

--- a/app/models/sprint_remaining_time.rb
+++ b/app/models/sprint_remaining_time.rb
@@ -1,0 +1,2 @@
+class SprintRemainingTime < ApplicationRecord
+end

--- a/app/models/sprint_time_tracking.rb
+++ b/app/models/sprint_time_tracking.rb
@@ -1,0 +1,2 @@
+class SprintTimeTracking < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,8 @@ Rails.application.routes.draw do
   end
 
   resource :reports do
-    get :total_remaing_time_in_sprint
+    post :save_sprint_remaining_time
+    get :total_sprint_remaining_time
   end
   root 'daily_work_logs#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
   end
 
   resource :reports do
-    post :save_sprint_remaining_time
-    get :total_sprint_remaining_time
+    post :save_sprint_time_tracking
+    get :total_sprint_time_tracking
   end
   root 'daily_work_logs#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/Schemafile
+++ b/db/Schemafile
@@ -3,3 +3,11 @@ create_table "users", force: :cascase do |t|
   t.string "jira_id", limit: 255
   t.string "position", limit:255
 end
+
+create_table "sprint_remaining_times", force: :cascase do |t|
+  t.integer  "user_id",        null: false, limit: 4,  unsigned: true
+  t.string   "jira_id",        null: false, limit: 255
+  t.string   "sprint_id",      null: false, limit: 255
+  t.bigint   "remaining_time", null: false,            unsigned: true
+  t.datetime "created_at",     null: false,                            precision: 6
+end

--- a/db/Schemafile
+++ b/db/Schemafile
@@ -4,10 +4,11 @@ create_table "users", force: :cascase do |t|
   t.string "position", limit:255
 end
 
-create_table "sprint_remaining_times", force: :cascase do |t|
+create_table "sprint_time_trackings", force: :cascase do |t|
   t.integer  "user_id",        null: false, limit: 4,  unsigned: true
   t.string   "jira_id",        null: false, limit: 255
   t.string   "sprint_id",      null: false, limit: 255
+  t.bigint   "time_spent", null: false,            unsigned: true
   t.bigint   "remaining_time", null: false,            unsigned: true
   t.datetime "created_at",     null: false,                            precision: 6
 end


### PR DESCRIPTION
## Summary
1. Create API to save current time tracking into DB (**All time trackings are created for all each users**)
API: `/reports/save_sprint_time_tracking?sprint_id=`
Response:
```
{
    "status": 200,
    "message": "Success ReportsController#save_sprint_time_tracking",
    "data": {
        "sprint_id": "",
        "time_trackings": [
            {
                "user_id": ,
                "jira_id": "",
                "time_spent":,
                "remaining_time":
            },
            {
                "user_id": ,
                "jira_id": "",
                "time_spent":,
                "remaining_time": 
            }
        ]
    }
}
```

2. Create API to get specific user's sprint time trackings
API: `/reports/total_sprint_time_tracking?user_ids=n,n,n,n,..&sprint_id=`
Response:
```
{
    "status": 200,
    "message": "Success ReportsController#total_sprint_time_tracking",
    "data": {
        "sprint_id": "",
        "total_time_trackings": [
            {
                "date": "2020-01-30T10:59:55.525Z",
                "time_trackings": [
                    {
                        "jira_id": "",
                        "time_spent":,
                        "remaining_time":
                    },
                    {
                        "jira_id": "",
                        "time_spent":,
                        "remaining_time":
                    },
                    {
                        "jira_id": "",
                        "time_spent":,
                        "remaining_time":
                    },
                    {
                        "jira_id": "",
                        "time_spent": ,
                        "remaining_time": 
                    }
                ]
            }
        ]
    }
}
```